### PR TITLE
Remove license file from containers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,9 @@ logs
 tmp
 *.tmp
 *.log
+xp/license
+xc/license
+.vs/ProjectSettings.json
+.vs/slnx.sqlite
+
+\.vs/

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Hopefully this will help you to get up and running with Sitecore and Docker. By 
 - Docker for Windows (version 18.09.1 or better): https://docs.docker.com/docker-for-windows/
 - Sitecore installation files
 - [Nuke.build](https://nuke.build)
+- A valid license.xml file
 
 
 # Build
@@ -21,6 +22,8 @@ For this you need to place the Sitecore installation files and a Sitecore licens
 - [XP images build config](./build/Build.Xp.cs)
 - [XC images build config](./build/Build.Xc.cs)
 - [Overall build config](./build/Build.cs)
+
+Put the license.xml in xp/license/ for xp containers or in xc/license/ for xc containers.
 
 The XP0 Sitecore topology requires SSL between the services, for this we need self signed certificates for the 
 xConnect and SOLR roles. You can generate these by running the `./Generate-Certificates.ps1` script (note that this requires an Administrator elevated powershell environment and you may need to set the correct execution policy, e.g. `PS> powershell.exe -ExecutionPolicy Unrestricted`).
@@ -181,8 +184,8 @@ To determine and set the root certificate to use for a HTTPS connection:
 1. Determine certificate used for IIS: `PS> Get-WebBinding | Select certificateHash`
 2. Determine root certificate used to sign the in step 1 obtained certificate: `PS> Get-ChildItem cert:\localmachine\my\<certificateHash> | Select Issuer`
 3. Lookup thumbprint of the issuer: `PS> Get-ChildItem cert:\localmachine\root\
-3. Export the root certificate: `PS> Export-Certificate -Cert cert:\localmachine\root\<thumbprint> -FilePath <file>`
-4. Import the root certificate (on the client): `PS> Import-Certificate <file> -CertStoreLocation cert:\localmachine\root`
+4. Export the root certificate: `PS> Export-Certificate -Cert cert:\localmachine\root\<thumbprint> -FilePath <file>`
+5. Import the root certificate (on the client): `PS> Import-Certificate <file> -CertStoreLocation cert:\localmachine\root`
 
 ## Commerce setup
 - We have quite a lot of custom powershell scripts for trivial installation tasks. This is because the commerce SIF scripts contain hardcoded values. For example, it is not possible to use hostnames other than localhost. We should be able to remove this custom code when those scripts get fixed.

--- a/base/sitecore/Dockerfile
+++ b/base/sitecore/Dockerfile
@@ -12,7 +12,7 @@ ARG VCREDISTX64_EXE=${INSTALL_TEMP}\\VC_redist.x64.exe
 ADD https://download.microsoft.com/download/0/1/D/01DC28EA-638C-4A22-A57B-4CEF97755C6C/WebDeploy_amd64_en-US.msi ${WEBDEPLOY_MSI}
 ADD https://download.microsoft.com/download/1/2/8/128E2E22-C1B9-44A4-BE2A-5859ED1D4592/rewrite_amd64_en-US.msi ${URLREWRITE_MSI}
 ADD https://aka.ms/vs/15/release/VC_redist.x64.exe ${VCREDISTX64_EXE}
-ADD /Scripts/Install-Vim.ps1 ${INSTALL_TEMP}
+COPY /Scripts/Install-Vim.ps1 ${INSTALL_TEMP}
 COPY base/sitecore/*.ps1 ${INSTALL_TEMP}
 
 # Install Sitecore dependencies, SIF, choco, vim

--- a/dummylicense.xml
+++ b/dummylicense.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet type="text/xsl" href="http://www.sitecore.net/licenseviewer/license.xsl"?>
+<signedlicense id="123">
+	<Signature>
+		<SignedInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
+			<CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315" />
+			<SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1" />
+			<Reference URI="#123">
+				<DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1" />
+				<DigestValue>123</DigestValue>
+			</Reference>
+		</SignedInfo>
+		<SignatureValue xmlns="http://www.w3.org/2000/09/xmldsig#">123</SignatureValue>
+		<KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
+			<KeyValue>
+				<RSAKeyValue>
+					<Modulus>123</Modulus>
+					<Exponent>123</Exponent>
+				</RSAKeyValue>
+			</KeyValue>
+		</KeyInfo>
+		<Object Id="SiteCore.License" xmlns="http://www.w3.org/2000/09/xmldsig#">
+			<license xmlns="">
+				<id>123</id>
+				<expiration>123</expiration>
+				<version>9</version>
+				<urls>?</urls>
+				<licensee>123</licensee>
+				<companyno />
+				<purpose />
+				<address />
+				<countryiso>NL</countryiso>
+				<country>Netherlands</country>
+				<reseller />
+				<resellerurl />
+				<licenseagreement id="123" title="License Agreement">
+					<![CDATA[Your usage rights to the Sitecore Software are as set forth in your license agreement with Sitecore.]]>
+				</licenseagreement>
+			</license>
+		</Object>
+	</Signature>
+</signedlicense>

--- a/xc/commerce/Dockerfile
+++ b/xc/commerce/Dockerfile
@@ -11,8 +11,8 @@ ARG SITECORE_BIZFX_PACKAGE
 
 WORKDIR /Files
 
-ADD files /Files
-ADD scripts /Scripts
+COPY files /Files
+COPY scripts /Scripts
 
 # Expand installation files
 RUN Expand-Archive -Force -Path "/Files/$Env:COMMERCE_SDK_PACKAGE" -DestinationPath '/Files/Sitecore.Commerce.SDK'; `
@@ -47,7 +47,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 WORKDIR /Files
 
 # Copy required files
-ADD scripts /Scripts
+COPY scripts /Scripts
 
 COPY files/*.pfx /Files/
 COPY --from=prepare /Files/Sitecore.Commerce.SDK /Files/Sitecore.Commerce.SDK/
@@ -142,7 +142,7 @@ RUN $certificates = Get-ChildItem -Path 'cert:\localmachine\my' -DnsName 'DO_NOT
     $binding = Get-WebBinding -Name 'SitecoreIdentityServer' -Protocol 'https'; `
     $binding.AddSslCertificate($certificate.GetCertHashString(), 'My');
 
-ADD xc/commerce/UpdateConnectionString.ps1 /Scripts
+COPY xc/commerce/UpdateConnectionString.ps1 /Scripts
 
 RUN /Scripts/UpdateConnectionString.ps1 -folder c:\inetpub\wwwroot\CommerceAuthoring_Sc9 `
     -userName 'sa' `
@@ -176,7 +176,7 @@ RUN $pathToAppSettings  = $(Join-Path -Path c:\inetpub\wwwroot\SitecoreIdentityS
 
 RUN $hostFileName = 'c:\\windows\\system32\\drivers\\etc\\hosts'; '\"`r`n127.0.0.1`t$Env:HOST_NAME\"' | Add-Content $hostFileName
 
-ADD xc/commerce/UpdateIdentityServerUrl.ps1 /Scripts
+COPY xc/commerce/UpdateIdentityServerUrl.ps1 /Scripts
 
 RUN /Scripts/UpdateIdentityServerUrl.ps1 -folder c:\inetpub\wwwroot\CommerceAuthoring_Sc9 `
     -hostName $Env:HOST_NAME; `
@@ -187,7 +187,7 @@ RUN /Scripts/UpdateIdentityServerUrl.ps1 -folder c:\inetpub\wwwroot\CommerceAuth
     /Scripts/UpdateIdentityServerUrl.ps1 -folder c:\inetpub\wwwroot\CommerceShops_Sc9 `
     -hostName $Env:HOST_NAME;
 
-ADD xc/commerce/UpdateSitecoreUrl.ps1 /Scripts
+COPY xc/commerce/UpdateSitecoreUrl.ps1 /Scripts
 
 RUN /Scripts/UpdateSitecoreUrl.ps1 -folder c:\inetpub\wwwroot\CommerceAuthoring_Sc9 `
     -hostName $Env:SITECORE_HOSTNAME; `
@@ -279,7 +279,7 @@ RUN Expand-Archive -Path "/Files/$Env:PLUMBER_FILE_NAME" -DestinationPath 'c:\\i
 # Expose Plumber port
 EXPOSE 4000
 
-ADD xc/commerce/WatchDirectoryMultiple.ps1 /Scripts
-ADD xc/commerce/WatchDefaultDirectories.ps1 /Scripts
+COPY xc/commerce/WatchDirectoryMultiple.ps1 /Scripts
+COPY xc/commerce/WatchDefaultDirectories.ps1 /Scripts
 
 ENTRYPOINT /Scripts/WatchDefaultDirectories.ps1

--- a/xc/docker-compose.yml
+++ b/xc/docker-compose.yml
@@ -36,6 +36,7 @@ services:
   volumes:
     - .\logs\sitecore:c:\inetpub\wwwroot\${SITECORE_SITE_NAME}\App_Data\logs
     - .\wwwroot\sitecore:C:\Workspace
+    - .\license:C:\license
   depends_on:
     - xconnect
     - mssql
@@ -56,6 +57,7 @@ services:
   isolation: process
   volumes:
     - .\logs\xconnect:C:\inetpub\wwwroot\xconnect\App_data\Logs
+    - .\license:C:\license
   depends_on:
     - mssql
     - solr

--- a/xc/sitecore/Dockerfile
+++ b/xc/sitecore/Dockerfile
@@ -13,7 +13,7 @@ ARG COMMERCE_XANALYTICS_PACKAGE
 
 SHELL ["powershell", "-NoProfile", "-Command", "$ErrorActionPreference = 'Stop';"]
 
-ADD files/ /Files/
+COPY files/ /Files/
 
 RUN Expand-Archive -Path "/Files/$Env:COMMERCE_SIF_PACKAGE" -DestinationPath /Files/CommerceSIF -Force; `
     Expand-Archive -Path "/Files/$Env:COMMERCE_CONNECT_PACKAGE" -DestinationPath /Files/SitecoreCommerceConnectCore -Force; `
@@ -42,9 +42,9 @@ COPY --from=builder /Files/${WEB_TRANSFORM_TOOL} /Files/Microsoft.Web.XmlTransfo
 COPY --from=builder /Files/${COMMERCE_CONNECT_ENGINE_PACKAGE} /Files/Sitecore.Commerce.Engine.Connect.update
 COPY --from=builder /Files/${ROOT_CERT_PATH} /Files/${ROOT_CERT_PATH}
 
-ADD xc/sitecore/InstallCommercePackages.ps1 /Scripts/
-ADD files/$COMMERCE_CERT_PATH /Files/
-ADD scripts/Import-Certificate.ps1 /Scripts/
+COPY xc/sitecore/InstallCommercePackages.ps1 /Scripts/
+COPY files/$COMMERCE_CERT_PATH /Files/
+COPY scripts/Import-Certificate.ps1 /Scripts/
 
 # Trust Self signed certificates & import XConnect certificate
 RUN /Scripts/Import-Certificate.ps1 -certificateFile /Files/$Env:COMMERCE_CERT_PATH -secret 'secret' -storeName 'Root' -storeLocation 'LocalMachine'; `
@@ -54,6 +54,6 @@ RUN /Scripts/Import-Certificate.ps1 -certificateFile /Files/$Env:COMMERCE_CERT_P
 
 # Patch Solr config, set initializeOnAdd = true
 # See: https://sitecore.stackexchange.com/questions/11523/index-sitecore-marketingdefinitions-master-was-not-found-exception-in-sitecore
-ADD xc/sitecore/Sitecore.Commerce.Engine.Connectors.Index.Solr.InitializeOnAdd.config /inetpub/wwwroot/sitecore/App_Config/Include/zSitecore.Commerce.Engine.Connectors.Index.Solr.InitializeOnAdd.config
+COPY xc/sitecore/Sitecore.Commerce.Engine.Connectors.Index.Solr.InitializeOnAdd.config /inetpub/wwwroot/sitecore/App_Config/Include/zSitecore.Commerce.Engine.Connectors.Index.Solr.InitializeOnAdd.config
 
 ENTRYPOINT /Scripts/Watch-Directory.ps1 -Path C:\Workspace -Destination c:\inetpub\wwwroot\sitecore

--- a/xc/solr/DockerFile
+++ b/xc/solr/DockerFile
@@ -8,7 +8,7 @@ ARG INSTALL_TEMP='c:\\install'
 ARG SITECORE_CORE_PREFIX
 ARG COMMERCE_SIF_PACKAGE
 
-ADD files/$COMMERCE_SIF_PACKAGE ${INSTALL_TEMP}/
+COPY files/$COMMERCE_SIF_PACKAGE ${INSTALL_TEMP}/
 
 RUN & 'c:/solr/bin/solr.cmd' start -p 8983; `
     Expand-Archive -Path (Join-Path $env:INSTALL_TEMP $env:COMMERCE_SIF_PACKAGE) -DestinationPath $env:INSTALL_TEMP; `

--- a/xc/solr/sxa/Dockerfile
+++ b/xc/solr/sxa/Dockerfile
@@ -7,7 +7,7 @@ FROM ${BUILDER_BASE_IMAGE} as builder
 ARG INSTALL_TEMP='c:\\install'
 ARG SITECORE_CORE_PREFIX="sitecore"
 
-ADD sxa-solr.json ${INSTALL_TEMP}/
+COPY sxa-solr.json ${INSTALL_TEMP}/
 
 RUN & 'c:/solr/bin/solr.cmd' start -p 8983; `
     Install-SitecoreConfiguration -Path (Join-Path $env:INSTALL_TEMP 'sxa-solr.json') `

--- a/xc/xconnect/Dockerfile
+++ b/xc/xconnect/Dockerfile
@@ -6,7 +6,7 @@ ARG COMMERCE_MA_FOR_AUTOMATION_ENGINE_PACKAGE
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ADD files/ /Files/
+COPY files/ /Files/
 
 # Extract Marketing Automation, see InstallAutomationEngineModule SIF task
 RUN Expand-Archive -Force -Path "/Files/$Env:COMMERCE_MA_FOR_AUTOMATION_ENGINE_PACKAGE" -DestinationPath C:\inetpub\wwwroot\xconnect; `

--- a/xp/docker-compose.yml
+++ b/xp/docker-compose.yml
@@ -17,6 +17,7 @@ services:
   isolation: process
   volumes:
     - .\logs\sitecore:c:\inetpub\wwwroot\${SITECORE_SITE_NAME}\App_Data\logs
+    - .\license:C:\license
     - .\wwwroot\sitecore:C:\Workspace
   depends_on:
     - xconnect
@@ -38,6 +39,7 @@ services:
   isolation: process
   volumes:
     - .\logs\xconnect:C:\inetpub\wwwroot\xconnect\App_data\Logs
+    - .\license:C:\license
   depends_on:
     - mssql
     - solr

--- a/xp/sitecore/Boot.ps1
+++ b/xp/sitecore/Boot.ps1
@@ -1,0 +1,11 @@
+$licenseFile = "C:/license/license.xml"
+if(Test-Path $licenseFile)
+{
+    Write-Host "Found license file"
+}
+else
+{
+    Write-Host "No license file found. Please put in a license.xml file in the /license folder"
+    exit
+}
+./Scripts/Watch-Directory.ps1 -Path C:\Workspace -Destination c:\inetpub\wwwroot\sitecore

--- a/xp/sitecore/Dockerfile
+++ b/xp/sitecore/Dockerfile
@@ -6,7 +6,7 @@ FROM ${BASE_IMAGE} AS prepare
 
 ARG CONFIG_PACKAGE
 
-ADD files /Files
+COPY files /Files
 
 RUN Expand-Archive -Path /Files/$Env:CONFIG_PACKAGE -DestinationPath /Files/Config 
 
@@ -26,10 +26,11 @@ ARG SITECORE_CORE_PREFIX
 ARG SITECORE_PACKAGE
 
 COPY files/*.pfx /Files/
-COPY files/license.xml /Files/
+COPY dummylicense.xml /license/license.xml
+COPY xp/sitecore/Boot.ps1 ./
 COPY files/$SITECORE_PACKAGE /Files/
 COPY --from=prepare /Files/Config /Files/Config/
-ADD scripts /Scripts
+COPY scripts /Scripts
 
 ENV XCONNECT_CLIENT_CERT_PATH "c:\\Files\\xconnect-client.pfx"
 ENV XCONNECT_SSL_CERT_PATH "c:\\Files\\xconnect-ssl.pfx"
@@ -55,7 +56,7 @@ RUN $config = Get-Content $Env:SIF_CONFIG | Where-Object { $_ -notmatch '^\s*\/\
 RUN $solrUrl = 'http://solr:{0}/solr' -f $Env:SOLR_PORT; `
     Install-SitecoreConfiguration -Path $Env:SIF_CONFIG `
     -Package c:/Files/$Env:SITECORE_PACKAGE `
-    -LicenseFile "c:/Files/license.xml" `
+    -LicenseFile "c:/license/license.xml" `
     -Sitename $Env:SITE_NAME `
     -SqlDbPrefix $Env:SQL_DB_PREFIX `
     -SqlServer $Env:SQL_SERVER `
@@ -98,8 +99,8 @@ RUN $pwd = ConvertTo-SecureString -String 'secret' -Force -AsPlainText; `
     $binding.AddSslCertificate($PFXCert.EndEntityCertificates.ThumbPrint, 'my')
 
 # Copy custom config & enable live-mode
-ADD xp/sitecore/config /Config
+COPY xp/sitecore/config /Config
 RUN Copy-Item /Config/*.* c:\inetpub\wwwroot\$Env:SITE_NAME\App_Config\Include; `
     mv C:\inetpub\wwwroot\sitecore\App_Config\Include\Examples\LiveMode.config.example C:\inetpub\wwwroot\sitecore\App_Config\Include\Examples\LiveMode.config
 
-ENTRYPOINT /Scripts/Watch-Directory.ps1 -Path C:\Workspace -Destination c:\inetpub\wwwroot\sitecore
+ENTRYPOINT /Boot.ps1

--- a/xp/sitecore/config/LicenseLocation.config
+++ b/xp/sitecore/config/LicenseLocation.config
@@ -1,0 +1,7 @@
+<configuration xmlns:patch="http://www.sitecore.net/xmlconfig/" xmlns:set="http://www.sitecore.net/xmlconfig/set/">
+  <sitecore>
+    <settings>
+      <setting name="LicenseFile" value="C:\license\license.xml" />
+    </settings>
+  </sitecore>
+</configuration>

--- a/xp/solr/DockerFile
+++ b/xp/solr/DockerFile
@@ -13,7 +13,7 @@ ARG XCONNECT_PACKAGE
 
 COPY files/$XCONNECT_PACKAGE /Files/
 COPY xp/solr/xconnect-xp0-configuresolrschemas.json ${INSTALL_TEMP}/
-ADD files/$CONFIG_PACKAGE ${INSTALL_TEMP}/
+COPY files/$CONFIG_PACKAGE ${INSTALL_TEMP}/
 
 RUN & 'c:/solr/bin/solr.cmd' start -p 8983; `
     Expand-Archive -Path (Join-Path $env:INSTALL_TEMP '*Configuration files*.zip') -DestinationPath $env:INSTALL_TEMP; `

--- a/xp/solr/sxa/Dockerfile
+++ b/xp/solr/sxa/Dockerfile
@@ -7,7 +7,7 @@ FROM ${BUILDER_BASE_IMAGE} as builder
 ARG INSTALL_TEMP='c:\\install'
 ARG SITECORE_CORE_PREFIX="Sitecore"
 
-ADD sxa-solr.json ${INSTALL_TEMP}/
+COPY sxa-solr.json ${INSTALL_TEMP}/
 
 RUN & 'c:/solr/bin/solr.cmd' start -p 8983; `
     Install-SitecoreConfiguration -Path (Join-Path $env:INSTALL_TEMP 'sxa-solr.json') `

--- a/xp/xconnect/DockerFile
+++ b/xp/xconnect/DockerFile
@@ -8,7 +8,8 @@ ARG CONFIG_PACKAGE
 
 SHELL ["powershell", "-NoProfile", "-Command", "$ErrorActionPreference = 'Stop';"]
 
-ADD files/$CONFIG_PACKAGE /Files/
+COPY files/$CONFIG_PACKAGE /Files/
+COPY [ "xp/xconnect/custom-settings.json", "xp/xconnect/register-services.json", "xp/xconnect/Invoke-RegisterWindowsService.psm1", "/Files/Config/" ]
 
 RUN Expand-Archive -Path /Files/$Env:CONFIG_PACKAGE -DestinationPath /Files/Config 
 
@@ -26,23 +27,23 @@ ARG XCONNECT_PACKAGE
 
 SHELL ["powershell", "-NoProfile", "-Command", "$ErrorActionPreference = 'Stop';"] 
 
-COPY files/license.xml /Files/
-COPY files/$XCONNECT_PACKAGE /Files/
 COPY files/*.pfx /Files/
+COPY files/$XCONNECT_PACKAGE /Files/
+COPY dummylicense.xml /license/license.xml
+COPY xp/xconnect/Boot.ps1 ./
 COPY --from=prepare /Files/Config /Files/Config/
 COPY xp/xconnect/custom-settings.json /Files/Config/
-ADD scripts /Scripts
+COPY scripts /Scripts
 
-ENV XCONNECT_CLIENT_CERT_PATH "C:\\Files\\xconnect-client.pfx"
-ENV XCONNECT_SSL_CERT_PATH "C:\\Files\\xconnect-ssl.pfx"
+ENV XCONNECT_CLIENT_CERT_PATH="C:\\Files\\xconnect-client.pfx"
+ENV XCONNECT_SSL_CERT_PATH="C:\\Files\\xconnect-ssl.pfx"
 ENV SITE_NAME=${SITE_NAME}
+ENV SIF_CONFIG="c:\\Files\\Config\\xconnect-xp0.json"
 
 # Trust Self signed certificates & import XConnect certificate
 RUN /Scripts/Import-Certificate.ps1 -certificateFile $Env:XCONNECT_SSL_CERT_PATH -secret 'secret' -storeName 'My' -storeLocation 'LocalMachine'; `
     /Scripts/Import-Certificate.ps1 -certificateFile $Env:XCONNECT_CLIENT_CERT_PATH -secret 'secret' -storeName 'Root' -storeLocation 'LocalMachine'; `
     /Scripts/Import-Certificate.ps1 -certificateFile $Env:XCONNECT_CLIENT_CERT_PATH -secret 'secret' -storeName 'My' -storeLocation 'LocalMachine'
-
-ENV SIF_CONFIG="c:\\Files\\Config\\xconnect-xp0.json"
 
 RUN $config = Get-Content $Env:SIF_CONFIG | Where-Object { $_ -notmatch '^\s*\/\/'} | Out-String | ConvertFrom-Json; `
     $config.Tasks.InstallWDP.Params.Arguments | Add-Member -Name 'Skip' -Value @(@{'ObjectName' = 'dbDacFx'}, @{'ObjectName' = 'dbFullSql'}) -MemberType NoteProperty; `
@@ -51,7 +52,7 @@ RUN $config = Get-Content $Env:SIF_CONFIG | Where-Object { $_ -notmatch '^\s*\/\
 RUN $solrUrl = 'http://solr:{0}/solr' -f $Env:SOLR_PORT; `
     Install-SitecoreConfiguration -Path $Env:SIF_CONFIG `
     -Package c:/Files/$Env:XCONNECT_PACKAGE `
-    -LicenseFile "c:\\Files\\license.xml" `
+    -LicenseFile "c:\\license\\license.xml" `
     -Sitename $Env:SITE_NAME `
     -XConnectCert "xConnect.client" `
     -SslCert "xconnect" `
@@ -72,10 +73,11 @@ RUN $solrUrl = 'http://solr:{0}/solr' -f $Env:SOLR_PORT; `
     -SolrCorePrefix $Env:SOLR_CORE_PREFIX `
     -SolrURL $solrUrl `
     -Skip "CleanShards", "CreateShards", "CreateShardApplicationDatabaseServerLoginSqlCmd", "CreateShardManagerApplicationDatabaseUserSqlCmd", `
-        "CreateShard0ApplicationDatabaseUserSqlCmd", "CreateShard1ApplicationDatabaseUserSqlCmd", "ConfigureSolrSchemas", "StartServices"; `
+        "CreateShard0ApplicationDatabaseUserSqlCmd", "CreateShard1ApplicationDatabaseUserSqlCmd", "ConfigureSolrSchemas", "StartServices", "InstallServices"; `
+    Install-SitecoreConfiguration -Path 'c:/Files/Config/register-services.json' -Sitename $Env:SITE_NAME; `
     Install-SitecoreConfiguration -Path 'c:/Files/Config/custom-settings.json' -Sitename $Env:SITE_NAME; `
     Remove-Item -Recurse -Force -Path c:\inetpub\wwwroot\xconnect\App_Data\logs
 
 EXPOSE 443
 
-ENTRYPOINT C:\ServiceMonitor.exe w3svc
+ENTRYPOINT /Boot.ps1

--- a/xp/xconnect/Invoke-RegisterWindowsService.psm1
+++ b/xp/xconnect/Invoke-RegisterWindowsService.psm1
@@ -1,0 +1,14 @@
+Set-StrictMode -Version 2.0
+ 
+Function Invoke-RegisterWindowsService {
+    [CmdletBinding(SupportsShouldProcess=$true)]
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]$Path,
+        [Parameter(Mandatory=$true)]
+        [string]$Name
+    )
+    $pathWithArguments = "$Path ""-service"""
+    New-Service -name $Name -binaryPathName $pathWithArguments -startupType Automatic
+}
+Register-SitecoreInstallExtension -Command Invoke-RegisterWindowsService -As RegisterWindowsService -Type Task

--- a/xp/xconnect/boot.ps1
+++ b/xp/xconnect/boot.ps1
@@ -1,0 +1,14 @@
+$licenseFile = "C:/license/license.xml"
+if(Test-Path $licenseFile)
+{
+    Write-Host "Found license file. Copying it to folders"
+    Copy-Item -Path $licenseFile -Destination "C:/inetpub/wwwroot/xconnect/App_Data"
+    Copy-Item -Path $licenseFile -Destination "C:/inetpub/wwwroot/xconnect/App_Data/jobs/continuous/AutomationEngine/App_Data"
+    Copy-Item -Path $licenseFile -Destination "C:/inetpub/wwwroot/xconnect/App_Data/jobs/continuous/IndexWorker/App_Data"
+}
+else
+{
+    Write-Host "No license file found. Please put in a license.xml file in the /license folder"
+    exit
+}
+C:\ServiceMonitor.exe w3svc

--- a/xp/xconnect/register-services.json
+++ b/xp/xconnect/register-services.json
@@ -1,0 +1,55 @@
+// -------------------------------------------------------------------------- //
+//         Sitecore Install Framework - XConnect XP0 Configuration            //
+//                                                                            //
+//  Run this configuration to install a single instance of XConnect.          //
+//                                                                            //
+//  NOTE: Only single line comments are accepted in configurations.           //
+// -------------------------------------------------------------------------- //
+{
+    "Parameters": {
+        // Parameters are values that may be passed when Install-SitecoreConfiguration is called.
+        // Parameters must declare a Type and may declare a DefaultValue and Description.
+        // Parameters with no DefaultValue are required when Install-SitecoreConfiguration is called.
+        "SiteName": {
+            "Type": "string",
+            "DefaultValue": "XConnect",
+            "Description": "The name of the site to be deployed."
+        }
+    },
+    "Variables": {
+        // The sites full path on disk
+        "Site.PhysicalPath": "[joinpath(environment('SystemDrive'), 'inetpub', 'wwwroot', parameter('SiteName'))]",
+        "Site.DataFolder":  "[joinpath(variable('Site.PhysicalPath'), 'App_Data')]",
+
+        // The path to the index worker windows service
+        "Services.IndexWorker.InstallPath": "[joinpath(variable('Site.DataFolder'), 'jobs','continuous','IndexWorker')]",
+        "Services.IndexWorker.Name":        "[concat(parameter('SiteName'), '-IndexWorker')]",
+
+        // The path to the automation engine windows service
+        "Services.MarketingAutomationEngine.InstallPath":   "[joinpath(variable('Site.DataFolder'), 'jobs','continuous','AutomationEngine')]",
+        "Services.MarketingAutomationEngine.Name":          "[concat(parameter('SiteName'), '-MarketingAutomationService')]"
+    },
+    "Tasks": {
+        // Tasks are separate units of work in a configuration.
+        // Each task is an action that will be completed when Install-SitecoreConfiguration is called.
+        // By default, tasks are applied in the order they are declared.
+        // Tasks may reference Parameters, Variables, and config functions.
+        "RegisterWindowsServices": {
+            // Registers the services.
+            "Type": "RegisterWindowsService",
+            "Params": [
+                {
+                    "Path": "[joinpath(variable('Services.IndexWorker.InstallPath'), 'XConnectSearchIndexer.exe')]",
+                    "Name": "[variable('Services.IndexWorker.Name')]"
+                },
+                {
+                    "Path": "[joinpath(variable('Services.MarketingAutomationEngine.InstallPath'), 'maengine.exe')]",
+                    "Name": "[variable('Services.MarketingAutomationEngine.Name')]"
+                }
+            ]
+        }
+    },
+    "Modules":[
+		"c:/Files/Config/Invoke-RegisterWindowsService.psm1"
+	]
+}


### PR DESCRIPTION
TODO
- [x] Replace license file in xconnect container with dummy license
- [x] Replace license file in sitecore container with dummy license
- [x] Replace license file in commerce container with dummy license (commerce container did not need a license file in the end)
- [x] Update readme

CLEANUP
- [x] Replaced ADD with COPY where possible to follow best practices (see 'ADD or COPY' in [Best practises](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/))