### PR TITLE
MCY-2652: Changed image versioning scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,11 +78,13 @@ Each Docker image (or set of images, e.g. `XP0` or `XC`) has a corresponding tar
 ### Push images
 To push the Docker images to your repository use the `push` build targets, e.g. to push all images:
 ```
-PS> nuke push
+PS> nuke Push --RepoImagePrefix <YourRepoNameHere>
 ```
 
-NB. To prefix the Docker images with your repository name change the `RepoImagePrefix`, `XpImagePrefix` and/or `XcImagePrefix` build setting parameters.
-
+The `BuildVersion` parameter may be used to optionally append a version to the image name:
+```
+PS> nuke Push --RepoImagePrefix <YourRepoNameHere> --BuildVersion <YourVersionHere>
+```
 
 # Run
 Docker compose is used to start up all required services. 
@@ -121,7 +123,6 @@ NB. these run-time parameters should match the used build parameters.
 ## DNS
 To set the Docker container service names as DNS names on your host edit your `hosts` file. 
 A convenient tool to automatically do this is [whales-names](https://github.com/gregolsky/whales-names).
-
 
 # Known issues
 Docker for Windows can be unstable at times, some troubleshooting tips are listed below.

--- a/build/Build.Base.cs
+++ b/build/Build.Base.cs
@@ -15,10 +15,7 @@ partial class Build : NukeBuild
     [Parameter("Docker image prefix for Sitecore base")]
     readonly string BaseImagePrefix = "sitecore-base-";
 
-    [Parameter("Docker image version tag for Sitecore base")]
-    readonly string BaseVersion = "1.0.0-ltsc2019";
-
-    private string BaseFullImageName(string name) => $"{RepoImagePrefix}{BaseImagePrefix}{name}:{BaseVersion}";
+    private string BaseFullImageName(string name) => $"{RepoImagePrefix}{BaseImagePrefix}{name}:{Tag}";
     
     Target BaseOpenJdk => _ => _
         .Executes(() =>

--- a/build/Build.Base.cs
+++ b/build/Build.Base.cs
@@ -11,11 +11,14 @@ using Nuke.Common.Tooling;
 
 partial class Build : NukeBuild
 {
+    [Parameter("Docker image sitecore version")]
+    public readonly string BaseSitecoreVersion = "1.0.0";
+    public string BaseTag => string.IsNullOrEmpty(BuildVersion) ? BaseSitecoreVersion : $"{BaseSitecoreVersion}-{BuildVersion}";
     // Docker image naming
     [Parameter("Docker image prefix for Sitecore base")]
     readonly string BaseImagePrefix = "sitecore-base-";
 
-    private string BaseFullImageName(string name) => $"{RepoImagePrefix}{BaseImagePrefix}{name}:{Tag}";
+    private string BaseFullImageName(string name) => $"{RepoImagePrefix}{BaseImagePrefix}{name}:{BaseTag}";
     
     Target BaseOpenJdk => _ => _
         .Executes(() =>

--- a/build/Build.Base.cs
+++ b/build/Build.Base.cs
@@ -13,13 +13,14 @@ partial class Build : NukeBuild
 {
     [Parameter("Docker image sitecore version")]
     public readonly string BaseSitecoreVersion = "1.0.0";
-    public string BaseTag => string.IsNullOrEmpty(BuildVersion) ? BaseSitecoreVersion : $"{BaseSitecoreVersion}-{BuildVersion}";
     // Docker image naming
     [Parameter("Docker image prefix for Sitecore base")]
     readonly string BaseImagePrefix = "sitecore-base-";
 
-    private string BaseFullImageName(string name) => $"{RepoImagePrefix}{BaseImageName(name)}";
-    private string BaseImageName(string name) => $"{BaseImagePrefix}{name}:{BaseTag}";
+    private string BaseFullImageName(string name) => string.IsNullOrEmpty(BuildVersion) ? 
+    $"{RepoImagePrefix}/{BaseImageName(name)}" : 
+    $"{RepoImagePrefix}/{BaseImageName(name)}-{BuildVersion}";
+    private string BaseImageName(string name) => $"{BaseImagePrefix}{name}:{BaseSitecoreVersion}";
     
     Target BaseOpenJdk => _ => _
         .Executes(() =>

--- a/build/Build.Xc.cs
+++ b/build/Build.Xc.cs
@@ -16,10 +16,7 @@ partial class Build : NukeBuild
     [Parameter("Docker image prefix for Sitecore XC")]
     readonly string XcImagePrefix = "sitecore-xc-";
 
-    [Parameter("Docker image version tag for Sitecore XC")]
-    readonly string XcVersion = "9.0.3-ltsc2019";
-
-    private string XcFullImageName(string name) => $"{RepoImagePrefix}{XcImagePrefix}{name}:{XcVersion}";
+    private string XcFullImageName(string name) => $"{RepoImagePrefix}{XcImagePrefix}{name}:{Tag}";
 
     // Packages
     [Parameter("Sitecore Identity server package")]
@@ -165,7 +162,7 @@ partial class Build : NukeBuild
             System.IO.Directory.SetCurrentDirectory("xc");
 
             Environment.SetEnvironmentVariable("IMAGE_PREFIX", $"{RepoImagePrefix}{XcImagePrefix}", EnvironmentVariableTarget.Process);
-            Environment.SetEnvironmentVariable("TAG", $"{XcVersion}", EnvironmentVariableTarget.Process);
+            Environment.SetEnvironmentVariable("TAG", $"{SitecoreVersion}", EnvironmentVariableTarget.Process);
 
             InstallSitecorePackage(
                 @"C:\Scripts\InstallCommercePackages.ps1", 
@@ -227,7 +224,7 @@ partial class Build : NukeBuild
             Environment.SetEnvironmentVariable("SXA_PACKAGE", $"{SXA_PACKAGE}", EnvironmentVariableTarget.Process);
             Environment.SetEnvironmentVariable("SCXA_PACKAGE", $"{SCXA_PACKAGE}", EnvironmentVariableTarget.Process);
             Environment.SetEnvironmentVariable("IMAGE_PREFIX", $"{RepoImagePrefix}{XcImagePrefix}", EnvironmentVariableTarget.Process);
-            Environment.SetEnvironmentVariable("TAG", $"{XcVersion}", EnvironmentVariableTarget.Process);
+            Environment.SetEnvironmentVariable("TAG", $"{SitecoreVersion}", EnvironmentVariableTarget.Process);
 
             InstallSitecorePackage(
                 @"C:\sxa\InstallSXA.ps1",

--- a/build/Build.Xc.cs
+++ b/build/Build.Xc.cs
@@ -14,13 +14,14 @@ partial class Build : NukeBuild
 {
     [Parameter("Docker image sitecore version")]
     public readonly string XcSitecoreVersion = "9.0.3";
-    public string XcTag => string.IsNullOrEmpty(BuildVersion) ? XcSitecoreVersion : $"{XcSitecoreVersion}-{BuildVersion}";
     // Docker image naming
     [Parameter("Docker image prefix for Sitecore XC")]
     readonly string XcImagePrefix = "sitecore-xc-";
 
-    private string XcFullImageName(string name) => $"{RepoImagePrefix}{XcImageName(name)}";
-    private string XcImageName(string name) => $"{XcImagePrefix}{name}:{XcTag}";
+    private string XcFullImageName(string name) => string.IsNullOrEmpty(BuildVersion) ? 
+    $"{RepoImagePrefix}/{XcImageName(name)}" : 
+    $"{RepoImagePrefix}/{XcImageName(name)}-{BuildVersion}";
+    private string XcImageName(string name) => $"{XcImagePrefix}{name}:{XcSitecoreVersion}";
 
     // Packages
     [Parameter("Sitecore Identity server package")]
@@ -169,7 +170,7 @@ partial class Build : NukeBuild
             System.IO.Directory.SetCurrentDirectory("xc");
 
             Environment.SetEnvironmentVariable("IMAGE_PREFIX", $"{RepoImagePrefix}{XcImagePrefix}", EnvironmentVariableTarget.Process);
-            Environment.SetEnvironmentVariable("TAG", $"{XcTag}", EnvironmentVariableTarget.Process);
+            Environment.SetEnvironmentVariable("TAG", $"{XcSitecoreVersion}", EnvironmentVariableTarget.Process);
 
             InstallSitecorePackage(
                 @"C:\Scripts\InstallCommercePackages.ps1", 
@@ -232,7 +233,7 @@ partial class Build : NukeBuild
             Environment.SetEnvironmentVariable("SXA_PACKAGE", $"{SXA_PACKAGE}", EnvironmentVariableTarget.Process);
             Environment.SetEnvironmentVariable("SCXA_PACKAGE", $"{SCXA_PACKAGE}", EnvironmentVariableTarget.Process);
             Environment.SetEnvironmentVariable("IMAGE_PREFIX", $"{RepoImagePrefix}{XcImagePrefix}", EnvironmentVariableTarget.Process);
-            Environment.SetEnvironmentVariable("TAG", $"{XcTag}", EnvironmentVariableTarget.Process);
+            Environment.SetEnvironmentVariable("TAG", $"{XcSitecoreVersion}", EnvironmentVariableTarget.Process);
 
             InstallSitecorePackage(
                 @"C:\sxa\InstallSXA.ps1",

--- a/build/Build.Xc.cs
+++ b/build/Build.Xc.cs
@@ -87,6 +87,8 @@ partial class Build : NukeBuild
     [Parameter("Commerce database prefix")]    
     readonly string COMMERCE_DB_PREFIX = "SitecoreCommerce9";
 
+    public AbsolutePath XcLicenseFile = RootDirectory / "xc" / "license" / "license.xml";
+
     Target XcCommerce => _ => _
         .Executes(() =>
         {
@@ -160,6 +162,7 @@ partial class Build : NukeBuild
         });
 
     Target XcSitecoreMssql => _ => _
+        .Requires(() => File.Exists(XcLicenseFile))
         .DependsOn(XcCommerce, XcMssqlIntermediate, XcSitecoreIntermediate, XcSolr, XcXconnect)
         .Executes(() => {
             System.IO.Directory.SetCurrentDirectory("xc");
@@ -215,6 +218,7 @@ partial class Build : NukeBuild
         });
 
     Target XcSitecoreMssqlSxa => _ => _
+        .Requires(() => File.Exists(XcLicenseFile))
         .DependsOn(XcSitecoreMssql, XcSolrSxa)
         .Executes(() => {
             var sifPackageFile = $"./Files/{COMMERCE_SIF_PACKAGE}";

--- a/build/Build.Xc.cs
+++ b/build/Build.Xc.cs
@@ -12,11 +12,14 @@ using Nuke.Common.Tooling;
 
 partial class Build : NukeBuild
 {
+    [Parameter("Docker image sitecore version")]
+    public readonly string XcSitecoreVersion = "9.0.3";
+    public string XcTag => string.IsNullOrEmpty(BuildVersion) ? XcSitecoreVersion : $"{XcSitecoreVersion}-{BuildVersion}";
     // Docker image naming
     [Parameter("Docker image prefix for Sitecore XC")]
     readonly string XcImagePrefix = "sitecore-xc-";
 
-    private string XcFullImageName(string name) => $"{RepoImagePrefix}{XcImagePrefix}{name}:{Tag}";
+    private string XcFullImageName(string name) => $"{RepoImagePrefix}{XcImagePrefix}{name}:{XcTag}";
 
     // Packages
     [Parameter("Sitecore Identity server package")]
@@ -162,7 +165,7 @@ partial class Build : NukeBuild
             System.IO.Directory.SetCurrentDirectory("xc");
 
             Environment.SetEnvironmentVariable("IMAGE_PREFIX", $"{RepoImagePrefix}{XcImagePrefix}", EnvironmentVariableTarget.Process);
-            Environment.SetEnvironmentVariable("TAG", $"{SitecoreVersion}", EnvironmentVariableTarget.Process);
+            Environment.SetEnvironmentVariable("TAG", $"{XcTag}", EnvironmentVariableTarget.Process);
 
             InstallSitecorePackage(
                 @"C:\Scripts\InstallCommercePackages.ps1", 
@@ -224,7 +227,7 @@ partial class Build : NukeBuild
             Environment.SetEnvironmentVariable("SXA_PACKAGE", $"{SXA_PACKAGE}", EnvironmentVariableTarget.Process);
             Environment.SetEnvironmentVariable("SCXA_PACKAGE", $"{SCXA_PACKAGE}", EnvironmentVariableTarget.Process);
             Environment.SetEnvironmentVariable("IMAGE_PREFIX", $"{RepoImagePrefix}{XcImagePrefix}", EnvironmentVariableTarget.Process);
-            Environment.SetEnvironmentVariable("TAG", $"{SitecoreVersion}", EnvironmentVariableTarget.Process);
+            Environment.SetEnvironmentVariable("TAG", $"{XcTag}", EnvironmentVariableTarget.Process);
 
             InstallSitecorePackage(
                 @"C:\sxa\InstallSXA.ps1",

--- a/build/Build.Xp.cs
+++ b/build/Build.Xp.cs
@@ -12,10 +12,14 @@ using Nuke.Common.Tooling;
 
 partial class Build : NukeBuild
 {
+    [Parameter("Docker image sitecore version")]
+    public readonly string XpSitecoreVersion = "9.0.2";
+    public string XpTag => string.IsNullOrEmpty(BuildVersion) ? XpSitecoreVersion : $"{XpSitecoreVersion}-{BuildVersion}";
+
     [Parameter("Docker image prefix for Sitecore XP")]
     public readonly string XpImagePrefix = "sitecore-xp-";
     
-    private string XpFullImageName(string name) => $"{RepoImagePrefix}{XpImagePrefix}{name}:{Tag}";
+    private string XpFullImageName(string name) => $"{RepoImagePrefix}{XpImagePrefix}{name}:{XpTag}";
 
     // Packages
     [Parameter("Sitecore XPO configuration package")]
@@ -141,7 +145,7 @@ partial class Build : NukeBuild
             Environment.SetEnvironmentVariable("PSE_PACKAGE", $"{PSE_PACKAGE}", EnvironmentVariableTarget.Process);
             Environment.SetEnvironmentVariable("SXA_PACKAGE", $"{SXA_PACKAGE}", EnvironmentVariableTarget.Process);
             Environment.SetEnvironmentVariable("IMAGE_PREFIX", $"{RepoImagePrefix}{XpImagePrefix}", EnvironmentVariableTarget.Process);
-            Environment.SetEnvironmentVariable("TAG", $"{SitecoreVersion}", EnvironmentVariableTarget.Process);
+            Environment.SetEnvironmentVariable("TAG", $"{XpTag}", EnvironmentVariableTarget.Process);
 
             InstallSitecorePackage(
                 @"C:\sxa\InstallSXA.ps1",

--- a/build/Build.Xp.cs
+++ b/build/Build.Xp.cs
@@ -15,10 +15,7 @@ partial class Build : NukeBuild
     [Parameter("Docker image prefix for Sitecore XP")]
     public readonly string XpImagePrefix = "sitecore-xp-";
     
-    [Parameter("Docker image version tag for Sitecore XP")]
-    readonly string XpVersion = "9.0.2-ltsc2019";
-
-    private string XpFullImageName(string name) => $"{RepoImagePrefix}{XpImagePrefix}{name}:{XpVersion}";
+    private string XpFullImageName(string name) => $"{RepoImagePrefix}{XpImagePrefix}{name}:{Tag}";
 
     // Packages
     [Parameter("Sitecore XPO configuration package")]
@@ -144,7 +141,7 @@ partial class Build : NukeBuild
             Environment.SetEnvironmentVariable("PSE_PACKAGE", $"{PSE_PACKAGE}", EnvironmentVariableTarget.Process);
             Environment.SetEnvironmentVariable("SXA_PACKAGE", $"{SXA_PACKAGE}", EnvironmentVariableTarget.Process);
             Environment.SetEnvironmentVariable("IMAGE_PREFIX", $"{RepoImagePrefix}{XpImagePrefix}", EnvironmentVariableTarget.Process);
-            Environment.SetEnvironmentVariable("TAG", $"{XpVersion}", EnvironmentVariableTarget.Process);
+            Environment.SetEnvironmentVariable("TAG", $"{SitecoreVersion}", EnvironmentVariableTarget.Process);
 
             InstallSitecorePackage(
                 @"C:\sxa\InstallSXA.ps1",

--- a/build/Build.Xp.cs
+++ b/build/Build.Xp.cs
@@ -50,6 +50,8 @@ partial class Build : NukeBuild
     [Parameter("Sitecore Solr core prefix")]
     readonly string SITECORE_SOLR_CORE_PREFIX = "sitecore";
 
+    public AbsolutePath XpLicenseFile = RootDirectory / "xp" / "license" / "license.xml";
+
     Target XpMssql => _ => _
         .Executes(() =>
         {
@@ -134,6 +136,7 @@ partial class Build : NukeBuild
         });
     
     Target XpSitecoreMssqlSxa => _ => _
+        .Requires(() => File.Exists(XpLicenseFile))
         .DependsOn(Xp)
         .Executes(() => {
             var sifPackageFile = $"./Files/{COMMERCE_SIF_PACKAGE}";

--- a/build/Build.Xp.cs
+++ b/build/Build.Xp.cs
@@ -14,13 +14,14 @@ partial class Build : NukeBuild
 {
     [Parameter("Docker image sitecore version")]
     public readonly string XpSitecoreVersion = "9.0.2";
-    public string XpTag => string.IsNullOrEmpty(BuildVersion) ? XpSitecoreVersion : $"{XpSitecoreVersion}-{BuildVersion}";
 
     [Parameter("Docker image prefix for Sitecore XP")]
     public readonly string XpImagePrefix = "sitecore-xp-";
     
-    private string XpFullImageName(string name) => $"{RepoImagePrefix}{XpImageName(name)}";
-    private string XpImageName(string name) => $"{XpImagePrefix}{name}:{XpTag}";
+    private string XpFullImageName(string name) => string.IsNullOrEmpty(BuildVersion) ? 
+    $"{RepoImagePrefix}/{XpImageName(name)}" :
+    $"{RepoImagePrefix}/{XpImageName(name)}-{BuildVersion}";
+    private string XpImageName(string name) => $"{XpImagePrefix}{name}:{XpSitecoreVersion}";
 
     // Packages
     [Parameter("Sitecore XPO configuration package")]
@@ -149,7 +150,7 @@ partial class Build : NukeBuild
             Environment.SetEnvironmentVariable("PSE_PACKAGE", $"{PSE_PACKAGE}", EnvironmentVariableTarget.Process);
             Environment.SetEnvironmentVariable("SXA_PACKAGE", $"{SXA_PACKAGE}", EnvironmentVariableTarget.Process);
             Environment.SetEnvironmentVariable("IMAGE_PREFIX", $"{RepoImagePrefix}{XpImagePrefix}", EnvironmentVariableTarget.Process);
-            Environment.SetEnvironmentVariable("TAG", $"{XpTag}", EnvironmentVariableTarget.Process);
+            Environment.SetEnvironmentVariable("TAG", $"{XpSitecoreVersion}", EnvironmentVariableTarget.Process);
 
             InstallSitecorePackage(
                 @"C:\sxa\InstallSXA.ps1",

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -12,12 +12,8 @@ using Nuke.Common.Tooling;
 
 partial class Build : NukeBuild
 {
-    [Parameter("Docker image sitecore version")]
-    public readonly string SitecoreVersion = "9.0.3";
     [Parameter("Docker image build version")]
     public readonly string BuildVersion = "";
-
-    public string Tag => string.IsNullOrEmpty(BuildVersion) ? SitecoreVersion : $"{SitecoreVersion}-{BuildVersion}";
 
     public static int Main () => Execute<Build>(x => x.All);
 
@@ -28,7 +24,7 @@ partial class Build : NukeBuild
 
     // Docker options
     [Parameter("Docker image repository prefix, e.g. my.docker-image.repo/")]
-    readonly string RepoImagePrefix = "avivasolutionsnl.azurecr.io/";
+    readonly string RepoImagePrefix = "";
 
     // Get the container created by docker-compose
     private string GetContainerName(string serviceName) {

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -12,6 +12,10 @@ using Nuke.Common.Tooling;
 
 partial class Build : NukeBuild
 {
+    /// <summary>
+    /// A build version that will be appended to the image name.
+    /// Ignored if its empty
+    /// </summary>
     [Parameter("Docker image build version")]
     public readonly string BuildVersion = "";
 

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -12,6 +12,13 @@ using Nuke.Common.Tooling;
 
 partial class Build : NukeBuild
 {
+    [Parameter("Docker image sitecore version")]
+    public readonly string SitecoreVersion = "9.0.3";
+    [Parameter("Docker image build version")]
+    public readonly string BuildVersion = "";
+
+    public string Tag => string.IsNullOrEmpty(BuildVersion) ? SitecoreVersion : $"{SitecoreVersion}-{BuildVersion}";
+
     public static int Main () => Execute<Build>(x => x.All);
 
     // Tools
@@ -21,7 +28,7 @@ partial class Build : NukeBuild
 
     // Docker options
     [Parameter("Docker image repository prefix, e.g. my.docker-image.repo/")]
-    readonly string RepoImagePrefix = "";
+    readonly string RepoImagePrefix = "avivasolutionsnl.azurecr.io/";
 
     // Get the container created by docker-compose
     private string GetContainerName(string serviceName) {

--- a/example/xc/.env
+++ b/example/xc/.env
@@ -1,6 +1,6 @@
 # Variables that are used in docker-compose files
 IMAGE_PREFIX=sitecore-xc-
-TAG=9.0.3-ltsc2019
+TAG=9.0.3
 
 SQL_SA_PASSWORD=my_Sup3rSecret!!
 

--- a/example/xc/docker-compose.yml
+++ b/example/xc/docker-compose.yml
@@ -16,8 +16,6 @@ services:
     - mssql
     - solr
     - sitecore
-  mem_limit: 4096m
-  cpu_count: 6
 
  mssql:
   image: "${IMAGE_PREFIX}mssql:${TAG}"
@@ -27,8 +25,6 @@ services:
     sa_password: ${SQL_SA_PASSWORD}
   volumes:
     - .\data\mssql:C:\Data
-  mem_limit: 4096m
-  cpu_count: 4
   
  sitecore:
   image: "${IMAGE_PREFIX}sitecore:${TAG}"
@@ -41,16 +37,12 @@ services:
     - xconnect
     - mssql
     - solr
-  mem_limit: 8192m
-  cpu_count: 6
   
  solr:
   image: "${IMAGE_PREFIX}solr:${TAG}"
   isolation: process
   volumes:
     - .\data\solr:C:\Data
-  mem_limit: 4096m
-  cpu_count: 4
   
  xconnect:
   image: "${IMAGE_PREFIX}xconnect:${TAG}"
@@ -61,5 +53,3 @@ services:
   depends_on:
     - mssql
     - solr
-  mem_limit: 2048m
-  cpu_count: 4

--- a/example/xp/.env
+++ b/example/xp/.env
@@ -1,6 +1,6 @@
 # Variables that are used in docker-compose files
 IMAGE_PREFIX=sitecore-xp-
-TAG=9.0.2-ltsc2019
+TAG=9.0.2
 
 SQL_SA_PASSWORD=my_Sup3rSecret!!
 

--- a/example/xp/docker-compose.yml
+++ b/example/xp/docker-compose.yml
@@ -9,8 +9,6 @@ services:
     sa_password: ${SQL_SA_PASSWORD}
   volumes:
     - .\data\mssql:C:\Data
-  mem_limit: 4096m
-  cpu_count: 4
 
  sitecore:
   image: "${IMAGE_PREFIX}sitecore:${TAG}"
@@ -23,16 +21,12 @@ services:
     - xconnect
     - mssql
     - solr
-  mem_limit: 8192m
-  cpu_count: 6
 
  solr:
   image: "${IMAGE_PREFIX}solr:${TAG}"
   isolation: process
   volumes:
     - .\data\solr:C:\Data
-  mem_limit: 4096m
-  cpu_count: 4
 
  xconnect:
   image: "${IMAGE_PREFIX}xconnect:${TAG}"
@@ -43,5 +37,3 @@ services:
   depends_on:
     - mssql
     - solr
-  mem_limit: 2048m
-  cpu_count: 4

--- a/xc/.env
+++ b/xc/.env
@@ -1,6 +1,6 @@
 # Variables that are used in docker-compose files
 IMAGE_PREFIX=sitecore-xc-
-TAG=9.0.3-ltsc2019
+TAG=9.0.3
 
 SQL_SA_PASSWORD=my_Sup3rSecret!!
 

--- a/xc/docker-compose.yml
+++ b/xc/docker-compose.yml
@@ -7,8 +7,6 @@ services:
   environment:
     ACCEPT_EULA: "Y"
     sa_password: ${SQL_SA_PASSWORD}
-  mem_limit: 4096m
-  cpu_count: 4
 
  sitecore:
   image: "${IMAGE_PREFIX}sitecore-intermediate:${TAG}"
@@ -19,14 +17,10 @@ services:
     - xconnect
     - mssql
     - solr
-  mem_limit: 8192m
-  cpu_count: 6
 
  solr:
   image: "${IMAGE_PREFIX}solr:${TAG}"
   isolation: process
-  mem_limit: 4096m
-  cpu_count: 4
 
  xconnect:
   image: "${IMAGE_PREFIX}xconnect:${TAG}"
@@ -36,8 +30,6 @@ services:
   depends_on:
     - mssql
     - solr
-  mem_limit: 2048m
-  cpu_count: 4
 
  commerce:
   image: "${IMAGE_PREFIX}commerce:${TAG}"
@@ -47,5 +39,3 @@ services:
     - mssql
     - solr
     - sitecore
-  mem_limit: 4096m
-  cpu_count: 6  

--- a/xp/.env
+++ b/xp/.env
@@ -1,6 +1,6 @@
 # Variables that are used in docker-compose files
 IMAGE_PREFIX=sitecore-xp-
-TAG=9.0.2-ltsc2019
+TAG=9.0.2
 
 SQL_SA_PASSWORD=my_Sup3rSecret!!
 

--- a/xp/docker-compose.yml
+++ b/xp/docker-compose.yml
@@ -7,8 +7,6 @@ services:
   environment:
     ACCEPT_EULA: "Y"
     sa_password: ${SQL_SA_PASSWORD}
-  mem_limit: 4096m
-  cpu_count: 4
 
  sitecore:
   image: "${IMAGE_PREFIX}sitecore:${TAG}"
@@ -19,14 +17,10 @@ services:
     - xconnect
     - mssql
     - solr
-  mem_limit: 8192m
-  cpu_count: 6
 
  solr:
   image: "${IMAGE_PREFIX}solr:${TAG}"
   isolation: process
-  mem_limit: 4096m
-  cpu_count: 4
 
  xconnect:
   image: "${IMAGE_PREFIX}xconnect:${TAG}"
@@ -36,5 +30,3 @@ services:
   depends_on:
     - mssql
     - solr
-  mem_limit: 2048m
-  cpu_count: 4

--- a/xp/mssql/Persist-Databases.ps1
+++ b/xp/mssql/Persist-Databases.ps1
@@ -13,8 +13,16 @@ Get-ChildItem -Path $DataPath -Filter "*.mdf" | ForEach-Object {
     Write-Host "### Detaching '$databaseName'..."
     $sqlcmd = "IF EXISTS (SELECT 1 FROM SYS.DATABASES WHERE NAME = '$databaseName') BEGIN EXEC MASTER.dbo.sp_detach_db @dbname = N'$databaseName', @keepfulltextindexfile = N'false', @skipchecks = N'true' END;"
     Invoke-Sqlcmd -Query $sqlcmd
+    if( -Not $?){
+        $msg = $Error[0].Exception.Message
+        throw "Encountered a error while executing a sql query: $msg"
+    }
 
     Write-Host "### Moving '$mdfPath' and '$ldfPath' to '$InstallPath'"
     Move-Item $mdfPath -Destination $InstallPath -Force
     Move-Item $ldfPath -Destination $InstallPath -Force
+}
+
+if(!((Get-ChildItem $DataPath | Measure-Object).Count -eq 0)){
+    throw "Something went wrong during persisting the databases as $DataPath is not empty"
 }


### PR DESCRIPTION
Changes:
- Changed versioning scheme to include the date
- Also contains some extra checks in Persist-Databases.ps1
- Added a check to check for if a license file exists. Since sxa build will fail if its missing there is no need to execute the build in this case.
- A image is now always build with the same tag. When pushing the image to the repository it will be tagged again but now the repository prefix and a optional buildversion is included.
- Removed cpu_count and mem_limit