### PR TITLE
Add xconnect SSL certificate to root

### DIFF
--- a/xp/xconnect/DockerFile
+++ b/xp/xconnect/DockerFile
@@ -77,8 +77,7 @@ RUN $solrUrl = 'http://solr:{0}/solr' -f $Env:SOLR_PORT; `
         "CreateShard0ApplicationDatabaseUserSqlCmd", "CreateShard1ApplicationDatabaseUserSqlCmd", "ConfigureSolrSchemas", "StartServices", "InstallServices"; `
     Install-SitecoreConfiguration -Path 'c:/Files/Config/register-services.json' -Sitename $Env:SITE_NAME; `
     Install-SitecoreConfiguration -Path 'c:/Files/Config/custom-settings.json' -Sitename $Env:SITE_NAME; `
-    Remove-Item -Recurse -Force -Path c:\inetpub\wwwroot\xconnect\App_Data\logs; `
-    net localgroup "Performance Monitor Users" $Env:SITE_NAME /add
+    Remove-Item -Recurse -Force -Path c:\inetpub\wwwroot\xconnect\App_Data\logs;
 
 EXPOSE 443
 

--- a/xp/xconnect/DockerFile
+++ b/xp/xconnect/DockerFile
@@ -41,7 +41,8 @@ ENV SITE_NAME=${SITE_NAME}
 ENV SIF_CONFIG="c:\\Files\\Config\\xconnect-xp0.json"
 
 # Trust Self signed certificates & import XConnect certificate
-RUN /Scripts/Import-Certificate.ps1 -certificateFile $Env:XCONNECT_SSL_CERT_PATH -secret 'secret' -storeName 'My' -storeLocation 'LocalMachine'; `
+RUN /Scripts/Import-Certificate.ps1 -certificateFile $Env:XCONNECT_SSL_CERT_PATH -secret 'secret' -storeName 'Root' -storeLocation 'LocalMachine'; `
+    /Scripts/Import-Certificate.ps1 -certificateFile $Env:XCONNECT_SSL_CERT_PATH -secret 'secret' -storeName 'My' -storeLocation 'LocalMachine'; `
     /Scripts/Import-Certificate.ps1 -certificateFile $Env:XCONNECT_CLIENT_CERT_PATH -secret 'secret' -storeName 'Root' -storeLocation 'LocalMachine'; `
     /Scripts/Import-Certificate.ps1 -certificateFile $Env:XCONNECT_CLIENT_CERT_PATH -secret 'secret' -storeName 'My' -storeLocation 'LocalMachine'
 
@@ -76,7 +77,8 @@ RUN $solrUrl = 'http://solr:{0}/solr' -f $Env:SOLR_PORT; `
         "CreateShard0ApplicationDatabaseUserSqlCmd", "CreateShard1ApplicationDatabaseUserSqlCmd", "ConfigureSolrSchemas", "StartServices", "InstallServices"; `
     Install-SitecoreConfiguration -Path 'c:/Files/Config/register-services.json' -Sitename $Env:SITE_NAME; `
     Install-SitecoreConfiguration -Path 'c:/Files/Config/custom-settings.json' -Sitename $Env:SITE_NAME; `
-    Remove-Item -Recurse -Force -Path c:\inetpub\wwwroot\xconnect\App_Data\logs
+    Remove-Item -Recurse -Force -Path c:\inetpub\wwwroot\xconnect\App_Data\logs; `
+    net localgroup "Performance Monitor Users" $Env:SITE_NAME /add
 
 EXPOSE 443
 


### PR DESCRIPTION
The Xconnect SSL certificate was not imported in the root which prevented the MarketingAutomation engine from connecting to https://xconnect.

In addition added the fix for the access denied warning: https://sitecore.stackexchange.com/questions/14193/xconnect-access-to-the-registry-key-global-is-denied