### PR TITLE
Fixed solr exist check in boot.cmd

### DIFF
--- a/xp/solr/Boot.cmd
+++ b/xp/solr/Boot.cmd
@@ -10,18 +10,17 @@ ECHO SOLR_PORT=%SOLR_PORT%
 ECHO INSTALL_PATH=%INSTALL_PATH%
 ECHO DATA_PATH=%DATA_PATH%
 
-IF EXIST "%DATA_PATH%\sitecore_*" (
-    IF EXIST "%DATA_PATH%\solr.xml" (
-        ECHO "### Existing Sitecore solr cores found in '%DATA_PATH%'..."
-
-        SET HAS_DATA="true"
-    )
+FOR /D %%d IN ("%DATA_PATH%\*") DO (
+	IF EXIST "%%d\core.properties" (
+		SET HAS_DATA="true"
+	)
 )
 
 IF %HAS_DATA%=="false" (
     ECHO "### No Sitecore Solr cores found in '%DATA_PATH%', seeding clean cores from '%INSTALL_PATH%'..."
-
     XCOPY %INSTALL_PATH% %DATA_PATH% /E
+) ELSE (
+    ECHO "### Existing Sitecore solr cores found in '%DATA_PATH%'..."
 )
 
 ECHO "### Preparing Solr cores..."

--- a/xp/solr/Boot.cmd
+++ b/xp/solr/Boot.cmd
@@ -10,7 +10,7 @@ ECHO SOLR_PORT=%SOLR_PORT%
 ECHO INSTALL_PATH=%INSTALL_PATH%
 ECHO DATA_PATH=%DATA_PATH%
 
-IF EXIST "%DATA_PATH%\sc_*" (
+IF EXIST "%DATA_PATH%\sitecore_*" (
     IF EXIST "%DATA_PATH%\solr.xml" (
         ECHO "### Existing Sitecore solr cores found in '%DATA_PATH%'..."
 

--- a/xp/solr/PersistCores.cmd
+++ b/xp/solr/PersistCores.cmd
@@ -16,14 +16,16 @@ IF "%2"=="" (
 ECHO INSTALL_PATH=%INSTALL_PATH%
 ECHO DATA_PATH=%DATA_PATH%
 
-IF EXIST "%DATA_PATH%\solr.xml" (
-    ECHO "### Existing Sitecore solr cores found in '%DATA_PATH%'..."
-    SET HAS_DATA="true"
+FOR /D %%d IN ("%DATA_PATH%\*") DO (
+	IF EXIST "%%d\core.properties" (
+		SET HAS_DATA="true"
+	)
 )
 
 IF %HAS_DATA%=="false" (
     ECHO "### Cannot persist cores. No Sitecore Solr cores found in '%DATA_PATH%'"    
 ) ELSE (
+    ECHO "### Existing Sitecore solr cores found in '%DATA_PATH%'..."
     ECHO "### Persisting cores from '%DATA_PATH%'" 
     XCOPY %DATA_PATH% %INSTALL_PATH% /E /Y
 )


### PR DESCRIPTION
The seeded cores have the following naming:
![image](https://user-images.githubusercontent.com/19387223/55540034-65054880-56c2-11e9-86f4-5fc3d2513134.png)

However boot.cmd was looking for sc_* as can be seen below:
![image](https://user-images.githubusercontent.com/19387223/55540133-97af4100-56c2-11e9-9dfc-0a775adcd4cf.png)


Changed this to sitecore_* so that it matches on the actual names