### PR TITLE
sitecore commerce connector config is now also updated with the new commerce url

### DIFF
--- a/example/xc/.env
+++ b/example/xc/.env
@@ -5,3 +5,6 @@ TAG=9.0.3
 SQL_SA_PASSWORD=my_Sup3rSecret!!
 
 SITECORE_SITE_NAME=sitecore
+
+COMMERCE_HOST_NAME=commerce.local
+SITECORE_HOST_NAME=sitecore

--- a/example/xc/docker-compose.yml
+++ b/example/xc/docker-compose.yml
@@ -4,10 +4,11 @@ services:
  commerce:
   image: "${IMAGE_PREFIX}commerce:${TAG}"
   isolation: process
+  command: -commerceHostname ${COMMERCE_HOST_NAME} -sitecoreHostname ${SITECORE_HOST_NAME}
   networks:
     exampleNetwork:
       aliases:
-        - commerce.local
+        - ${COMMERCE_HOST_NAME}
   volumes:
     - .\logs\commerce\CommerceAuthoring_Sc9:C:\inetpub\wwwroot\CommerceAuthoring_Sc9\wwwroot\logs
     - .\logs\commerce\CommerceMinions_Sc9:C:\inetpub\wwwroot\CommerceMinions_Sc9\wwwroot\logs
@@ -34,9 +35,12 @@ services:
   
  sitecore:
   image: "${IMAGE_PREFIX}sitecore:${TAG}"
+  command: -commerceHostname ${COMMERCE_HOST_NAME}
   isolation: process
   networks:
-    - exampleNetwork 
+    exampleNetwork:
+      aliases:
+        - ${SITECORE_HOST_NAME}
   volumes:
     - .\logs\sitecore:c:\inetpub\wwwroot\${SITECORE_SITE_NAME}\App_Data\logs
     - .\wwwroot\sitecore:C:\Workspace

--- a/xc/sitecore/Boot.ps1
+++ b/xc/sitecore/Boot.ps1
@@ -1,0 +1,11 @@
+param(
+    [Parameter(Mandatory=$true)]
+    [String]$commerceHostname
+)
+
+/Scripts/UpdateHostname.ps1 -commerceHostname $commerceHostname
+
+If ((Test-Path C:\Workspace) -eq $False) { 
+    New-Item -Type Directory c:\Workspace  
+}
+/Scripts/Watch-Directory.ps1 -Path C:\Workspace -Destination c:\inetpub\wwwroot\sitecore

--- a/xc/sitecore/Dockerfile
+++ b/xc/sitecore/Dockerfile
@@ -56,5 +56,8 @@ RUN /Scripts/Import-Certificate.ps1 -certificateFile /Files/$Env:COMMERCE_CERT_P
 # See: https://sitecore.stackexchange.com/questions/11523/index-sitecore-marketingdefinitions-master-was-not-found-exception-in-sitecore
 COPY xc/sitecore/Sitecore.Commerce.Engine.Connectors.Index.Solr.InitializeOnAdd.config /inetpub/wwwroot/sitecore/App_Config/Include/zSitecore.Commerce.Engine.Connectors.Index.Solr.InitializeOnAdd.config
 
-ENTRYPOINT If ((Test-Path C:\Workspace) -eq $False) { New-Item -Type Directory c:\Workspace  }; `
-    /Scripts/Watch-Directory.ps1 -Path C:\Workspace -Destination c:\inetpub\wwwroot\sitecore
+COPY xc/sitecore/UpdateHostname.ps1 /Scripts
+COPY xc/sitecore/Boot.ps1 C:/
+
+ENTRYPOINT ["powershell", "C:/Boot.ps1"]
+CMD [ "-commerceHostname commerce.local" ]

--- a/xc/sitecore/UpdateHostname.ps1
+++ b/xc/sitecore/UpdateHostname.ps1
@@ -1,0 +1,25 @@
+Param(
+    [Parameter(Mandatory = $true)]
+    [String]$commerceHostname
+)
+
+Function UpdateCommerceConfig() {
+    param(
+        [Parameter(Mandatory = $true)]
+        [String]$commerceHostname
+    )
+
+    # Modify the commerce engine connection
+    $engineConnectIncludeDir = 'c:\\inetpub\\wwwroot\\sitecore\\App_Config\\Include\\Y.Commerce.Engine'
+    $configPath = $(Join-Path -Path $engineConnectIncludeDir -ChildPath "\Sitecore.Commerce.Engine.Connect.config")
+
+    Write-Host "Patching $configPath with $commerceHostname"
+    $xml = [xml](Get-Content $configPath)
+    $node = $xml.configuration.sitecore.commerceEngineConfiguration
+    $node.shopsServiceUrl = "https://$commerceHostname" + ":5000/api/"
+    $node.commerceOpsServiceUrl = "https://$commerceHostname" + ":5000/commerceops/"
+    $xml.Save($configPath);
+    Write-Host "Done patching $configPath!" -ForegroundColor Green
+}
+
+UpdateCommerceConfig -commerceHostname $commerceHostname


### PR DESCRIPTION
Continuation from #99 

Changes:
- C:\inetpub\wwwroot\sitecore\App_Config\Include\Y.Commerce.Engine\Sitecore.Commerce.Engine.Connect.config is now also updated with the commerce hostname to make sure these are in sync
- Moved these hostnames in the example xc folder to the .env file. The idea is to eventually define all required hostnames here. This way the hostnames can be defined in a single spot for a given environment.

Why not use the default commerce url? Because eventually the services in the commerce containers will run in separate containers with each having a different name. This means we won't use the default commerce name anymore.