### PR TITLE
Mssql boot script fixes

### DIFF
--- a/xp/mssql/Boot.ps1
+++ b/xp/mssql/Boot.ps1
@@ -23,6 +23,11 @@ else
     Write-Host "### Existing Sitecore databases found in '$DataPath'..."
 }
 
+
+Write-Host "Waiting for the the MSSQLSERVER service to start..."
+(Get-Service MSSQLSERVER).WaitForStatus('Running')
+Write-Host "MSSQLSERVER service is now running!" -ForegroundColor Green
+
 Get-ChildItem -Path $DataPath -Filter "*.mdf" | ForEach-Object {
     # Replace case-insensitive,
     # Move-Item removes casing: https://stackoverflow.com/questions/54437210/move-item-and-preserve-filename-casing?noredirect=1#comment95683944_54437210

--- a/xp/mssql/Boot.ps1
+++ b/xp/mssql/Boot.ps1
@@ -48,7 +48,7 @@ Get-ChildItem -Path $DataPath -Filter "*.mdf" | ForEach-Object {
         Write-Host "The following error occurred while attaching $databaseName : $ErrorMessage"
         Write-Host "### Repairing '$databaseName'..."
         
-        $repairCmd = "ALTER DATABASE $databaseName SET EMERGENCY; DBCC CHECKDB ($databaseName, REPAIR_ALLOW_DATA_LOSS) WITH NO_INFOMSGS";
+        $repairCmd = "ALTER DATABASE [$databaseName] SET EMERGENCY; DBCC CHECKDB ([$databaseName], REPAIR_ALLOW_DATA_LOSS) WITH NO_INFOMSGS";
         Invoke-Sqlcmd -Query $repairCmd -Querytimeout 65535 -ConnectionTimeout 65535
     }
 }

--- a/xp/mssql/Dockerfile
+++ b/xp/mssql/Dockerfile
@@ -49,6 +49,7 @@ COPY files/$XCONNECT_PACKAGE ${INSTALL_PATH}/
 COPY xp/mssql/*.ps1 ${INSTALL_PATH}
 
 ADD https://dist.nuget.org/win-x86-commandline/v4.1.0/nuget.exe C:\\Windows\\nuget.exe
+
 RUN New-Item -Path 'C:/tools' -ItemType Directory | Out-Null; `
     & nuget install Microsoft.Data.Tools.Msbuild -Version 10.0.61710.120 -OutputDirectory c:/tools
     


### PR DESCRIPTION
Fixes:
- Prevents a race condition where sql queries could be fired off before the sql container was started
- Prevents sql query timeouts on slow machines because the timeout is now enlarged.
- Set database to single user to prevent errors on detaching (on attach its reset to normal)
