### PR TITLE
Added comment in the mssql dockerfile explaining why we install nuget and msbuild tools.

### DIFF
--- a/xp/mssql/Dockerfile
+++ b/xp/mssql/Dockerfile
@@ -48,6 +48,7 @@ COPY files/$XCONNECT_PACKAGE ${INSTALL_PATH}/
 
 COPY xp/mssql/*.ps1 ${INSTALL_PATH}
 
+# Install some utilities to handle dacpac files (like SqlPackage.exe)
 ADD https://dist.nuget.org/win-x86-commandline/v4.1.0/nuget.exe C:\\Windows\\nuget.exe
 
 RUN New-Item -Path 'C:/tools' -ItemType Directory | Out-Null; `


### PR DESCRIPTION
Was unclear why these were installed, see #122 