### PR TITLE
Enlarge and configurable robocopy timeout 

### DIFF
--- a/scripts/Watch-Directory.ps1
+++ b/scripts/Watch-Directory.ps1
@@ -10,6 +10,12 @@ param(
     $Destination
 )
 
+# Milliseconds to sleep between sync operations
+$SleepMilliseconds = 5000
+if (Get-Item -Path Env:WatchSleepMilliseconds -ErrorAction SilentlyContinue) {
+    $SleepMilliseconds = $Env:WatchSleepMilliseconds
+}
+
 function Sync
 {
     param(
@@ -74,7 +80,7 @@ try
     {
         Sync -Path $Path -Destination $Destination | Write-Host
 
-        Start-Sleep -Milliseconds 200
+        Start-Sleep -Milliseconds $SleepMilliseconds
     }
 }
 finally 

--- a/scripts/WatchDirectoryMultiple.ps1
+++ b/scripts/WatchDirectoryMultiple.ps1
@@ -13,6 +13,11 @@ param(
     [array]$Ignore = @("*\obj\*", "*.cs", "*.csproj", "*.user")
 )
 
+# Milliseconds to sleep between sync operations
+$SleepMilliseconds = 5000
+if (Get-Item -Path Env:WatchSleepMilliseconds -ErrorAction SilentlyContinue) {
+    $SleepMilliseconds = $Env:WatchSleepMilliseconds
+}
 function Sync 
 {
     Foreach($destination in $Destinations) {
@@ -51,5 +56,5 @@ Foreach($destination in $Destinations) {
 while($true) {   
     Sync | Write-Host
 
-    Sleep -Milliseconds 500
+    Sleep -Milliseconds $SleepMilliseconds
 }


### PR DESCRIPTION
The previous values (200 msec, 500 msec) cause an unnecessary high CPU load.

Therefore this PR enlarges the robocopy timeout to 5 seconds and allows $Env:WatchSleepMilliseconds to override this value.