### PR TITLE
Fix xconnect crash because starting services failed

### DIFF
--- a/xp/xconnect/Boot.ps1
+++ b/xp/xconnect/Boot.ps1
@@ -22,7 +22,11 @@ if(Test-Path $licenseFile)
         Start-Service "xconnect-ProcessingEngineService"
         Write-Host "Succesfully started the xconnect services" -ForegroundColor Green
     } catch {
-        Write-Host "Failed to start all services"
+        Write-Host "Failed to start all services. Retrying..."
+        Start-Service "xconnect-IndexWorker"
+        Start-Service "xconnect-MarketingAutomationService"
+        Start-Service "xconnect-ProcessingEngineService"
+        Write-Host "Succesfully started the xconnect services" -ForegroundColor Green
     }
 }
 else


### PR DESCRIPTION
The xconnect container woudl crash because one of the xconnect services
failed to start for unknown reasons.
As a workaround when the services fail to start a second attempt
is done to start the services.