### PR TITLE
Add query to build the Descendants table

### DIFF
--- a/xc/mssql/Dockerfile
+++ b/xc/mssql/Dockerfile
@@ -23,6 +23,7 @@ COPY files/$COMMERCE_MA_PACKAGE ${INSTALL_PATH}/
 COPY files/$COMMERCE_XPROFILES_PACKAGE ${INSTALL_PATH}/
 COPY files/$COMMERCE_XANALYTICS_PACKAGE ${INSTALL_PATH}/
 COPY xc/mssql/*.ps1 ${INSTALL_PATH}
+COPY xc/mssql/RebuildDescendants.sql ${INSTALL_PATH}
 COPY files/$COMMERCE_SIF_PACKAGE ${INSTALL_PATH}
 COPY scripts/Install-SIF.ps1 ${INSTALL_PATH}
 
@@ -48,5 +49,8 @@ RUN & (Join-Path $env:INSTALL_PATH "Attach-Databases.ps1"); `
     # Add Commerce Users and Roles
     Install-SitecoreConfiguration -Path $usersAndRolesConfig `
     -ConnectionString ("'Data Source=.;Initial Catalog={0}_Core;Integrated Security=true;'" -f $Env:SQL_DB_PREFIX); `
+    # Rebuild Descendants task
+    $env:MasterDatase = '{0}_Master' -f $Env:SQL_DB_PREFIX; `
+    Invoke-Sqlcmd -Database $Env:MasterDatase -InputFile (Join-Path $env:INSTALL_PATH "RebuildDescendants.sql"); `
     & (Join-Path $env:INSTALL_PATH "Detach-Databases.ps1"); `    
     Get-ChildItem -Path $env:INSTALL_PATH -Exclude "*.mdf", "*.ldf" | Remove-Item -Force -Recurse;

--- a/xc/mssql/RebuildDescendants.sql
+++ b/xc/mssql/RebuildDescendants.sql
@@ -1,0 +1,40 @@
+/* Rebuild Descendants Commerce SIF task. Query taken from the Sitecore.Data.SqlServer.SqlServerDataProvider.RebuildDescendants() method. */
+DECLARE @descendants TABLE (
+  [Ancestor] [uniqueidentifier] NOT NULL,
+  [Descendant] [uniqueidentifier] NOT NULL,
+  PRIMARY KEY([Ancestor], [Descendant])
+);
+
+WITH TempSet([Ancestor], [Descendant]) AS
+(
+  SELECT
+    [Items].[ParentID],
+    [Items].[ID]
+  FROM
+    [Items]
+  UNION ALL
+  SELECT
+    [Items].[ParentID],
+    [TempSet].[Descendant]
+  FROM
+    [Items] JOIN [TempSet]
+      ON [TempSet].[Ancestor] = [Items].[ID]
+)
+INSERT INTO @descendants([Ancestor], [Descendant])
+SELECT
+  [TempSet].[Ancestor],
+  [TempSet].[Descendant]
+FROM
+  [TempSet]
+OPTION (MAXRECURSION 32767)
+MERGE [Descendants] AS [Target]
+USING @descendants AS [Source]
+ON (
+  [Target].[Ancestor] = [Source].[Ancestor]
+  AND [Target].[Descendant] = [Source].[Descendant]
+)
+WHEN NOT MATCHED BY TARGET THEN
+  INSERT ([ID], [Ancestor], [Descendant])
+  VALUES (NEWID(), [Source].[Ancestor], [Source].[Descendant])
+WHEN NOT MATCHED BY SOURCE THEN
+  DELETE;


### PR DESCRIPTION
XC 9.2.0 introduced the RebuildDescendants task which will call the Sitecore.Data.SqlServer.SqlServerDataProvider.RebuildDescendants() method.
The Descendants table stores "ancestors-descendants" relations between items and is sed by FastQuery functionality (Sitecore.Data.DataProviders.Sql.FastQuery).

The query  executed by the RebuildDescendants has been added as part of building the XcMssql target.